### PR TITLE
Fix typo for lodash/cloneDeep import.

### DIFF
--- a/src/components/WrapPage.tsx
+++ b/src/components/WrapPage.tsx
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/clonedeep';
+import cloneDeep from 'lodash/cloneDeep';
 import gql from 'graphql-tag';
 import pick from 'lodash/pick';
 import get from 'lodash/get';


### PR DESCRIPTION
This seems to solve the build issue that happens whenever I try to build this branch. It might also solve the same issue when installing this plugin in another project, as a dependency.