### PR TITLE
Add formatting for page types

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -211,9 +211,12 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     endCursor: string = '',
     documents: Edge[] = []
   ): Promise<Edge[]> {
+    // Format page.type so that the graphql query doesn't complain.
+    const pageTypeUnderscored = page.type.toLowerCase().split(' ').join('_');
+    const pageTypeFormatted = pageTypeUnderscored.charAt(0).toUpperCase() + pageTypeUnderscored.slice(1);
     // Prepare and execute query
-    const documentType: string = `all${page.type}s`;
-    const sortType: string = `PRISMIC_Sort${page.type}y`;
+    const documentType: string = `all${pageTypeFormatted}s`;
+    const sortType: string = `PRISMIC_Sort${pageTypeFormatted}y`;
     const extraPageFields = options.extraPageFields || '';
     const query: string = getDocumentsQuery({ documentType, sortType, extraPageFields });
     const { data, errors } = await graphql(query, {


### PR DESCRIPTION
Should fix the following issue: https://github.com/birkir/gatsby-source-prismic-graphql/issues/200#issuecomment-630947309

As I wrote in the comments, the issue is that the page type that's seen in the prismic dashboard, doesn't correspond to the one used by graphql. So I've added formatting to the string, so that the user doesn't have to care about this.