### PR TITLE
fix: issue #18 remove gatsby-image sharp nodes on preview queries

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -31,7 +31,7 @@ const stripSharp = (query: any) => {
       x.value.match(/Sharp$/) &&
       !x.value.match(/.+childImageSharp$/)
     ) {
-      this.parent.remove();
+      this.parent.delete();
     }
   });
 };


### PR DESCRIPTION
### Summary

`stripSharp` function doesn't fully remove all gatsby image sharp nodes on preview queries. Replacing the traverse `remove` method in favor to `delete` fixed the issue.

### Changelog

The change is small, I've only changed the function to remove the node.

### Tests

https://codesandbox.io/s/prismic-graphql-strip-sharp-test-popsh?file=/index.test.js

