### PR TITLE
fix(withpreview.tsx): narrow the type definition of withPreview.tsx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .DS_Store
+.idea

--- a/packages/gatsby-source-prismic-graphql/src/components/withPreview.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/withPreview.tsx
@@ -1,32 +1,25 @@
 import React from 'react';
 import { WrapPage } from './WrapPage';
-import { StaticQueryProps } from 'gatsby';
 
-export type StaticQueryRender<T> = Required<StaticQueryProps<T>>['render'];
-
-export const withPreview = <T extends any = any>(
-  render: StaticQueryRender<T>,
+export const withPreview = <Data extends any = any>(
+  render: (data: Data) => JSX.Element,
   query: any,
   fragments: any = []
-): StaticQueryRender<T> => {
+): ((data: Data) => JSX.Element) | null => {
   if (typeof window === 'undefined') {
     return render;
   }
 
-  // shouldn't the type of the render argument be `render?: ...` if we are going to handle it not being defined?
-  // this is the case that someone would call `withPreview()` with no arguments...why not just throw an error?
   if (!render) {
-    return (null as unknown) as StaticQueryRender<T>;
+    return null;
   }
 
-  // this is interesting (a.k.a. concerning) - has to be case to JSX.Element for some reason
-  const RenderComponent = ({ data }: any) => render(data) as JSX.Element;
-  // it would be nice to narrow down the `any` for the query argument, but `typeof graphql` doesn't work...also interesting
+  const RenderComponent = ({ data }: any) => render(data);
   const rootQuery = `${query.source}${fragments
     .map((fragment: any) => (fragment && fragment.source ? fragment.source : ''))
     .join(' ')}`;
 
-  return (data: T) => (
+  return (data: any) => (
     <WrapPage
       data={data}
       pageContext={{ rootQuery }}

--- a/packages/gatsby-source-prismic-graphql/src/components/withPreview.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/withPreview.tsx
@@ -1,21 +1,32 @@
 import React from 'react';
 import { WrapPage } from './WrapPage';
+import { StaticQueryProps } from 'gatsby';
 
-export const withPreview = (render: Function, query: any, fragments: any = []) => {
+export type StaticQueryRender<T> = Required<StaticQueryProps<T>>['render'];
+
+export const withPreview = <T extends any = any>(
+  render: StaticQueryRender<T>,
+  query: any,
+  fragments: any = []
+): StaticQueryRender<T> => {
   if (typeof window === 'undefined') {
     return render;
   }
 
+  // shouldn't the type of the render argument be `render?: ...` if we are going to handle it not being defined?
+  // this is the case that someone would call `withPreview()` with no arguments...why not just throw an error?
   if (!render) {
-    return null;
+    return (null as unknown) as StaticQueryRender<T>;
   }
 
-  const RenderComponent = ({ data }: any) => render(data);
+  // this is interesting (a.k.a. concerning) - has to be case to JSX.Element for some reason
+  const RenderComponent = ({ data }: any) => render(data) as JSX.Element;
+  // it would be nice to narrow down the `any` for the query argument, but `typeof graphql` doesn't work...also interesting
   const rootQuery = `${query.source}${fragments
     .map((fragment: any) => (fragment && fragment.source ? fragment.source : ''))
     .join(' ')}`;
 
-  return (data: any) => (
+  return (data: T) => (
     <WrapPage
       data={data}
       pageContext={{ rootQuery }}


### PR DESCRIPTION
The return type of withPreview.tsx was not explicitly declared before, leaving typescript to infer it.  The inferred type was not compatible with what gatsby's StaticQuery component expected, causing users to need to cast it themselves, which is less than ideal.