### PR TITLE
feat(withpreviewcomponent): component that just renders its children

### DIFF
--- a/packages/gatsby-source-prismic-graphql/package.json
+++ b/packages/gatsby-source-prismic-graphql/package.json
@@ -61,7 +61,7 @@
     "@types/lodash": "4.14.121",
     "@types/node": "11.9.4",
     "@types/node-fetch": "2.1.6",
-    "@types/react": "16.8.4",
+    "@types/react": "16.9.43",
     "@types/styled-components": "^4.1.12",
     "@types/traverse": "^0.6.32",
     "cross-env": "^5.2.0",

--- a/packages/gatsby-source-prismic-graphql/src/components/WithPreviewComponent.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WithPreviewComponent.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { WrapPage } from '@prismicio/gatsby-source-prismic-graphql';
+import { WrapPage } from './WrapPage';
 
 export type WithPreviewProps<T> = PropsWithChildren<{
   data: T;

--- a/packages/gatsby-source-prismic-graphql/src/components/WithPreviewComponent.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WithPreviewComponent.tsx
@@ -1,0 +1,36 @@
+import React, { PropsWithChildren } from 'react';
+import { WrapPage } from '@prismicio/gatsby-source-prismic-graphql';
+
+export type WithPreviewProps<T> = PropsWithChildren<{
+  data: T;
+  query: any;
+  fragments?: any[];
+}>;
+
+/**
+ * our own WithPreview helper
+ */
+export const WithPreviewComponent = <Data,>({
+  query,
+  fragments = [],
+  children,
+  data,
+}: WithPreviewProps<Data>) => {
+  if (typeof window === 'undefined') {
+    return <>{children}</>;
+  }
+
+  const rootQuery = `${query.source}${fragments
+    .map((fragment: any) => (fragment && fragment.source ? fragment.source : ''))
+    .join(' ')}`;
+
+  return (
+    <WrapPage
+      data={data}
+      pageContext={{ rootQuery }}
+      options={(window as any).prismicGatsbyOptions || {}}
+    >
+      {children}
+    </WrapPage>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,10 +3189,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/react@16.8.4":
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
-  integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
+"@types/react@16.9.43":
+  version "16.9.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
+  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
@MarcMcIntosh @ohlr @lucashfreitas @Floriferous this is what I wrote in my own project...seems simpler...

usage:

```
export const Homepage: FC = () => {
  const data = useStaticQuery(homepageQuery);
  return (
    <WithPreview query={homepageQuery} data={data}>
      <MyComponent
        data={data}
      />
    </WithPreview>
  );
};
```

thoughts?