### PR TITLE
Use correct package name in README

### DIFF
--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -36,13 +36,13 @@ Please **be sure your Prismic repository has the GraphQL API enabled**. It is en
 **Install the plugin**
 
 ```bash
-npm install --save gatsby-source-prismic-graphql
+npm install --save @prismicio/gatsby-source-prismic-graphql
 ```
 
 or
 
 ```bash
-yarn add gatsby-source-prismic-graphql
+yarn add @prismicio/gatsby-source-prismic-graphql
 ```
 
 **Add plugin to `gatsby-config.js` and configure**


### PR DESCRIPTION
Update README installation instructions to use correct (scoped) package name