### PR TITLE
fix: add ref to new prismic preview library

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
@@ -25,7 +25,7 @@ exports.onRenderBody = ({ setHeadComponents }: OnRenderBodyArgs, options: Plugin
       <script
         key="prismic-script"
         type="text/javascript"
-        src="//static.cdn.prismic.io/prismic.min.js"
+        src="//static.cdn.prismic.io/prismic.min.js?new=true"
       />
     );
   }


### PR DESCRIPTION
Adds reference to new prismic.min.js to resolve issue with being unable to close prismic preview module (which were a result of Chrome cookie policy changes)

Details of issue here: https://community.prismic.io/t/cant-close-the-preview-module-chrome/1707/14